### PR TITLE
Add the "example" faction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.pbo
 *.bin
 !*
-$PREFIX$
 
 # executables
 *.com

--- a/addons/czarmy/$PREFIX$
+++ b/addons/czarmy/$PREFIX$
@@ -1,0 +1,1 @@
+cnto\factions\czarmy

--- a/addons/darkops/$PREFIX$
+++ b/addons/darkops/$PREFIX$
@@ -1,0 +1,1 @@
+cnto\factions\darkops

--- a/addons/example/$PBOPREFIX$
+++ b/addons/example/$PBOPREFIX$
@@ -1,0 +1,1 @@
+cnto\factions\example

--- a/addons/example/$PREFIX$
+++ b/addons/example/$PREFIX$
@@ -1,0 +1,1 @@
+cnto\factions\example

--- a/addons/example/CfgVehicles.h
+++ b/addons/example/CfgVehicles.h
@@ -1,0 +1,84 @@
+#include "details.h"
+#include "\cnto\factions\shared\include.h"
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// This faction is intentionally simple and straightforward - no custom weapons,
+// no EventHandlers (init lines), nothing too special.
+//
+
+class B_Soldier_base_F;
+
+class FACTION(template) : B_Soldier_base_F {
+    scope = 0;
+    side = FACTION_SIDE_NR;
+    faction = FACTION_CLASSNAME;
+    genericNames = "EnglishMen";
+    identityTypes[] = {
+        "LanguageENG_F",
+        "Head_Euro",
+        "G_NATO_casual"
+    };
+    class EventHandlers : EventHandlers {
+        FACTION_INITFUNC(setLoadout);
+    };
+};
+
+class FACTION(team_leader) : FACTION(template) {
+    scope = 2;
+    displayName = "Team Leader";
+    icon = "iconManLeader";
+};
+
+class FACTION(rifleman) : FACTION(template) {
+    scope = 2;
+    displayName = "Rifleman";
+    icon = "iconMan";
+};
+
+class FACTION(rifleman_at) : FACTION(template) {
+    scope = 2;
+    displayName = "Rifleman AT";
+    icon = "iconManAT";
+};
+
+class FACTION(machinegunner) : FACTION(template) {
+    scope = 2;
+    displayName = "Machine Gunner";
+    icon = "iconManMG";
+};
+
+class FACTION(medic) : FACTION(template) {
+    scope = 2;
+    displayName = "Medic";
+    icon = "iconManMedic";
+    attendant = 1;
+};
+
+class FACTION(crew) : FACTION(template) {
+    scope = 2;
+    displayName = "Crew";
+    icon = "iconManEngineer";
+    engineer = 1;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+//
+// vehicles (wheeled, tracked, airborne, naval, etc.)
+//
+
+class B_LSV_01_unarmed_F;
+class FACTION(prowler) : B_LSV_01_unarmed_F {
+    side = FACTION_SIDE_NR;
+    faction = FACTION_CLASSNAME;
+    VEHICLE_CREW(rifleman);
+};
+
+class B_APC_Wheeled_01_cannon_F;
+class FACTION(marshall) : B_APC_Wheeled_01_cannon_F {
+    side = FACTION_SIDE_NR;
+    faction = FACTION_CLASSNAME;
+    VEHICLE_CREW(crew);
+};

--- a/addons/example/config.cpp
+++ b/addons/example/config.cpp
@@ -1,0 +1,61 @@
+#include "details.h"
+#include "\cnto\factions\shared\include.h"
+
+class CfgPatches {
+    class FACTION_CLASSNAME {
+        units[] = {
+            // soldiers
+            FACTION(team_leader),
+            FACTION(rifleman),
+            FACTION(rifleman_at),
+            FACTION(machinegunner),
+            FACTION(medic),
+            FACTION(crew),
+            // land vehicles
+            FACTION(prowler),
+            FACTION(marshall)
+        };
+        weapons[] = {};
+        requiredAddons[] = {
+            "cnto_factions_shared",
+            "A3_Characters_F",
+            "A3_Soft_F_Exp_LSV_01",
+            "A3_Armor_F_Beta_APC_Wheeled_01"
+        };
+    };
+};
+
+class CfgFactionClasses {
+    class FACTION_CLASSNAME {
+        displayName = FACTION_DISPLAYNAME;
+        side = FACTION_SIDE_NR;
+    };
+};
+class CfgEditorSubcategories {
+    class FACTION_CLASSNAME {
+        displayName = FACTION_DISPLAYNAME;
+    };
+};
+
+class EventHandlers;
+class CfgVehicles {
+#include "CfgVehicles.h"
+};
+
+class CfgGroups {
+    class FACTION_GRP_CLASS {
+        class FACTION_CLASSNAME {
+            name = FACTION_DISPLAYNAME;
+#include "groups.h"
+        };
+    };
+};
+
+class CfgFunctions {
+    class FACTION_CLASSNAME {
+        class all {
+            file = FACTION_PATH;
+            class setLoadout;
+        };
+    };
+};

--- a/addons/example/details.h
+++ b/addons/example/details.h
@@ -1,0 +1,14 @@
+//
+// These *must* be modified/revised for each faction individually
+//
+
+// machine-friendly faction identifier - must be unique, contain
+// no spaces or special characters (underscores allowed)
+#define FACTION_ID example
+
+// human-readable faction name (keep it short)
+#define FACTION_HUMAN Example Faction
+
+// faction "side" (where will it appear in editor/Zeus menus)
+// one of: WEST, EAST, GUER, CIV
+#define FACTION_SIDE_GUER

--- a/addons/example/fn_setLoadout.sqf
+++ b/addons/example/fn_setLoadout.sqf
@@ -1,0 +1,49 @@
+#include "details.h"
+#include "\cnto\factions\shared\include.h"
+
+//
+// This file is an SQF script called on initialization of every soldier unit
+//
+
+params ["_unit"];
+if (!local _unit) exitWith {};
+
+// don't override Arsenal-customized loadout
+if (_unit call cnto_factions_fnc_hasModifiedLoadout) exitWith {};
+
+//
+// The big blocks of text below are from ACE arsenal "EXPORT"
+// (updated 2022/10 for new ACE3 arsenal syntax)
+//
+
+private _loadout = switch (typeOf _unit) do {
+
+    case QFACTION(team_leader): {
+[[["SMG_03_TR_black","","","optic_Aco",["50Rnd_570x28_SMG_03",50],[],""],[],["hgun_P07_F","","","",["16Rnd_9x21_Mag",17],[],""],["U_C_Driver_1_black",[["ACE_fieldDressing",1],["ACE_packingBandage",1],["ACE_morphine",1],["ACE_tourniquet",1],["50Rnd_570x28_SMG_03",1,50]]],["V_Rangemaster_belt",[["50Rnd_570x28_SMG_03",3,50]]],[],"H_Cap_blk_CMMG","",["Binocular","","","",[],[],""],["ItemMap","","ItemRadioAcreFlagged","ItemCompass","Itemwatch",""]], []]
+    };
+
+    case QFACTION(rifleman): {
+[[["SMG_03_TR_camo","","","optic_Aco",["50Rnd_570x28_SMG_03",50],[],""],[],["hgun_P07_F","","","",["16Rnd_9x21_Mag",17],[],""],["U_C_Driver_1_red",[["ACE_fieldDressing",1],["ACE_packingBandage",1],["ACE_morphine",1],["ACE_tourniquet",1],["50Rnd_570x28_SMG_03",1,50]]],["V_Rangemaster_belt",[["50Rnd_570x28_SMG_03",3,50]]],[],"H_Cap_red","",["Binocular","","","",[],[],""],["ItemMap","","ItemRadioAcreFlagged","ItemCompass","Itemwatch",""]], []]
+    };
+
+    case QFACTION(rifleman_at): {
+[[["SMG_03_TR_khaki","","","optic_Aco",["50Rnd_570x28_SMG_03",50],[],""],["launch_RPG32_F","","","",["RPG32_F",1],[],""],["hgun_P07_F","","","",["16Rnd_9x21_Mag",17],[],""],["U_C_Driver_1_blue",[["ACE_fieldDressing",1],["ACE_packingBandage",1],["ACE_morphine",1],["ACE_tourniquet",1],["50Rnd_570x28_SMG_03",1,50]]],["V_Rangemaster_belt",[["50Rnd_570x28_SMG_03",3,50]]],["B_AssaultPack_cbr",[["RPG32_F",2,1]]],"H_Cap_khaki_specops_UK","",["Binocular","","","",[],[],""],["ItemMap","","ItemRadioAcreFlagged","ItemCompass","Itemwatch",""]], []]
+    };
+
+    case QFACTION(machinegunner): {
+[[["LMG_Mk200_F","","","",["200Rnd_65x39_cased_Box",200],[],""],[],["hgun_P07_F","","","",["16Rnd_9x21_Mag",17],[],""],["U_C_Driver_1_blue",[["ACE_fieldDressing",1],["ACE_packingBandage",1],["ACE_morphine",1],["ACE_tourniquet",1]]],["V_Rangemaster_belt",[["HandGrenade",2,1]]],["B_AssaultPack_blk",[["200Rnd_65x39_cased_Box",2,200]]],"H_Cap_police","",["Binocular","","","",[],[],""],["ItemMap","","ItemRadioAcreFlagged","ItemCompass","Itemwatch",""]], []]
+    };
+
+    case QFACTION(medic): {
+[[["SMG_03_TR_hex","","","optic_Aco",["50Rnd_570x28_SMG_03",50],[],""],[],["hgun_P07_F","","","",["16Rnd_9x21_Mag",17],[],""],["U_C_Driver_1_yellow",[["ACE_fieldDressing",1],["ACE_packingBandage",1],["ACE_morphine",1],["ACE_tourniquet",1],["SmokeShell",1,1],["50Rnd_570x28_SMG_03",1,50]]],["V_Rangemaster_belt",[["SmokeShell",1,1],["50Rnd_570x28_SMG_03",3,50]]],["B_Kitbag_tan",[["ACE_elasticBandage",20],["ACE_packingBandage",20],["ACE_quikclot",10],["ACE_fieldDressing",10],["ACE_bloodIV",4],["ACE_epinephrine",15],["ACE_surgicalKit",1],["ACE_morphine",15]]],"H_Cap_surfer","",["Binocular","","","",[],[],""],["ItemMap","","ItemRadioAcreFlagged","ItemCompass","Itemwatch",""]], []]
+    };
+
+    case QFACTION(crew): {
+[[["SMG_03C_TR_black","","","optic_Aco",["50Rnd_570x28_SMG_03",50],[],""],[],["hgun_P07_F","","","",["16Rnd_9x21_Mag",17],[],""],["U_C_Driver_1",[["ACE_fieldDressing",1],["ACE_packingBandage",1],["ACE_morphine",1],["ACE_tourniquet",1],["50Rnd_570x28_SMG_03",1,50]]],["V_Rangemaster_belt",[["50Rnd_570x28_SMG_03",2,50]]],["B_AssaultPack_rgr",[["ToolKit",1],["SmokeShellGreen",2,1],["SmokeShellBlue",1,1],["SmokeShell",4,1]]],"H_Cap_grn_BI","",["Binocular","","","",[],[],""],["ItemMap","","ItemRadioAcreFlagged","ItemCompass","Itemwatch",""]], []]
+    };
+
+};
+
+private _facewear = goggles _unit;
+_unit setUnitLoadout [_loadout select 0, false];
+_unit addGoggles _facewear;

--- a/addons/example/groups.h
+++ b/addons/example/groups.h
@@ -1,0 +1,60 @@
+#include "details.h"
+#include "\cnto\factions\shared\include.h"
+
+class Infantry {
+    name = "Infantry";
+    class Fireteam {
+        name = "Fireteam";
+        icon = NATO_ICON(inf);
+        faction = FACTION_CLASSNAME;
+        side = FACTION_SIDE_NR;
+        class Unit0 { vehicle = FACTION(team_leader);   position[] = {0,0,0};     rank = "CORPORAL"; side = FACTION_SIDE_NR; };
+        class Unit1 { vehicle = FACTION(rifleman_at);   position[] = {5,-5,0};    rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit2 { vehicle = FACTION(machinegunner); position[] = {-5,-5,0};   rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit3 { vehicle = FACTION(rifleman);      position[] = {10,-10,0};  rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+    };
+    class Squad {
+        name = "Squad";
+        icon = NATO_ICON(inf);
+        faction = FACTION_CLASSNAME;
+        side = FACTION_SIDE_NR;
+        class Unit0 { vehicle = FACTION(team_leader);   position[] = {0,0,0};     rank = "SERGEANT"; side = FACTION_SIDE_NR; };
+        class Unit1 { vehicle = FACTION(rifleman_at);   position[] = {5,-5,0};    rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit2 { vehicle = FACTION(medic);         position[] = {-5,-5,0};   rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit3 { vehicle = FACTION(machinegunner); position[] = {10,-10,0};  rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit4 { vehicle = FACTION(rifleman);      position[] = {-10,-10,0}; rank = "CORPORAL"; side = FACTION_SIDE_NR; };
+        class Unit5 { vehicle = FACTION(machinegunner); position[] = {15,-15,0};  rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit6 { vehicle = FACTION(rifleman_at);   position[] = {-15,-15,0}; rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit7 { vehicle = FACTION(rifleman);      position[] = {20,-20,0};  rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+    };
+};
+
+class Motorized {
+    name = "Motorized Infantry";
+    class Patrol {
+        name = "Patrol (Prowler)";
+        icon = NATO_ICON(motor_inf);
+        faction = FACTION_CLASSNAME;
+        side = FACTION_SIDE_NR;
+        class Unit0 { vehicle = FACTION(team_leader);   position[] = {0,0,0};     rank = "CORPORAL"; side = FACTION_SIDE_NR; };
+        class Unit1 { vehicle = FACTION(rifleman_at);   position[] = {5,-5,0};    rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit2 { vehicle = FACTION(machinegunner); position[] = {-5,-5,0};   rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit3 { vehicle = FACTION(medic);         position[] = {10,-10,0};  rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit4 { vehicle = FACTION(prowler);       position[] = {-10,-10,0}; rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+    };
+    class Squad {
+        name = "Squad (Marshall)";
+        icon = NATO_ICON(motor_inf);
+        faction = FACTION_CLASSNAME;
+        side = FACTION_SIDE_NR;
+        class Unit0 { vehicle = FACTION(team_leader);   position[] = {0,0,0};     rank = "SERGEANT"; side = FACTION_SIDE_NR; };
+        class Unit1 { vehicle = FACTION(rifleman_at);   position[] = {5,-5,0};    rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit2 { vehicle = FACTION(medic);         position[] = {-5,-5,0};   rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit3 { vehicle = FACTION(machinegunner); position[] = {10,-10,0};  rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit4 { vehicle = FACTION(rifleman);      position[] = {-10,-10,0}; rank = "CORPORAL"; side = FACTION_SIDE_NR; };
+        class Unit5 { vehicle = FACTION(machinegunner); position[] = {15,-15,0};  rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit6 { vehicle = FACTION(rifleman_at);   position[] = {-15,-15,0}; rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit7 { vehicle = FACTION(rifleman);      position[] = {20,-20,0};  rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+        class Unit8 { vehicle = FACTION(marshall);      position[] = {25,-25,0};  rank = "PRIVATE";  side = FACTION_SIDE_NR; };
+    };
+};

--- a/addons/shared/$PREFIX$
+++ b/addons/shared/$PREFIX$
@@ -1,0 +1,1 @@
+cnto\factions\shared


### PR DESCRIPTION
This should hopefully be even more trivial than `czarmy` (no vehicle texture changes, etc.) and is even more generic (using English voices, vanilla assets, etc.) and minimalist (no ammo bearer, marksman, dedicated anti-tank, etc.).

The faction loadouts use the new ACE3 Arsenal EXPORT format, to remain easy-to-copypaste.

Also, this PR fixes an issue where `$PREFIX$` was incorrectly missing due to a bad `.gitignore` definition.